### PR TITLE
[#62] nGrinder 서버 cron job으로 관리

### DIFF
--- a/.github/workflows/release-server-1.yml
+++ b/.github/workflows/release-server-1.yml
@@ -52,10 +52,9 @@ jobs:
             set -e
             sudo docker ps -q --filter name=${{ env.IMAGE_NAME }} | grep -q . && docker stop ${{ env.IMAGE_NAME }} && docker rm -fv ${{ env.IMAGE_NAME }}
             sudo docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            sudo docker run -d --rm \
+            sudo docker run -e PROFILE=prod -d --rm \
             --name=${{ env.IMAGE_NAME }} \
             -p 8080:8080 \
-            --PROFILE=prod
             --add-host=host.docker.internal:host-gateway \
             -v /home/ubuntu/workspace/heeverse/logs:/workspace/heeverse/logs \
             -v /home/ubuntu/workspace/scouter:/workspace/heeverse/scouter \

--- a/.github/workflows/server-start-scheduler.yml
+++ b/.github/workflows/server-start-scheduler.yml
@@ -1,0 +1,28 @@
+name: server-start
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+
+jobs:
+  server-start:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Make the script files executable
+        run: chmod +x ./script/runNcpApi.sh
+
+      - name: Start nGrinder Servers
+        run: |
+          set -e
+          ./script/ncpAddIp.sh
+        env:
+          NGRINDER_AGENT_INSTANCE_ID: ${{ secrets.NGRINDER_AGENT_INSTANCE_ID }}
+          NGRINDER_CONTROLLER_INSTANCE_ID: ${{ secrets.NGRINDER_CONTROLLER_INSTANCE_ID }}
+          NCP_ACCESS_KEY: ${{ secrets.NCP_ACCESS_KEY }}
+          NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
+          API_PATH: startServerInstances

--- a/.github/workflows/server-stop-scheduler.yml
+++ b/.github/workflows/server-stop-scheduler.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 19 * * *'
 
 jobs:
-  server-start:
+  server-stop:
     runs-on: ubuntu-latest
     environment: prod
 

--- a/.github/workflows/server-stop-scheduler.yml
+++ b/.github/workflows/server-stop-scheduler.yml
@@ -1,0 +1,28 @@
+name: server-stop
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+
+jobs:
+  server-start:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Make the script files executable
+        run: chmod +x ./script/runNcpApi.sh
+
+      - name: Stop nGrinder Servers
+        run: |
+          set -e
+          ./script/ncpAddIp.sh
+        env:
+          NGRINDER_AGENT_INSTANCE_ID: ${{ secrets.NGRINDER_AGENT_INSTANCE_ID }}
+          NGRINDER_CONTROLLER_INSTANCE_ID: ${{ secrets.NGRINDER_CONTROLLER_INSTANCE_ID }}
+          NCP_ACCESS_KEY: ${{ secrets.NCP_ACCESS_KEY }}
+          NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
+          API_PATH: stopServerInstances

--- a/script/ncpAddIp.sh
+++ b/script/ncpAddIp.sh
@@ -19,11 +19,11 @@ function makeSignature() {
 	SIGNATURE=$(echo -n -e "$SIG"|iconv -t utf8 |openssl dgst -sha256 -hmac $SECRETKEY -binary|openssl enc -base64)
 
 
-	curl --location 'https://ncloud.apigw.ntruss.com'$URI \
+	curl -s 'https://ncloud.apigw.ntruss.com'$URI \
 		--header "Content-type:application/json" \
 		--header "x-ncp-apigw-timestamp:$TIMESTAMP" \
 		--header "x-ncp-iam-access-key:$ACCESSKEY" \
-		--header "x-ncp-apigw-signature-v2:$SIGNATURE"
+		--header "x-ncp-apigw-signature-v2:$SIGNATURE | sed -n 's/.*<returnCode>\(.*\)<\/returnCode>.*/\1/p'"
 
 }
 

--- a/script/runNcpApi.sh
+++ b/script/runNcpApi.sh
@@ -6,11 +6,12 @@ function makeSignature() {
 	TIMESTAMP=$(echo $(($(date +%s%N)/1000000)))
 	ACCESSKEY=$NCP_ACCESS_KEY
 	SECRETKEY=$NCP_SECRET_KEY
+	NCP_SERVER_API_PATH=$API_PATH
+	NGRINDER_AGENT=$NGRINDER_AGENT_INSTANCE_ID
+	NGRINDER_CONTROLLER=$NGRINDER_CONTROLLER_INSTANCE_ID
 
 	METHOD="GET"
-	URI="/vserver/v2/removeAccessControlGroupInboundRule?regionCode=KR&vpcNo=$VPC_NO&accessControlGroupNo=$ACCESS_CONTROL_GROUP_NO&accessControlGroupRuleList.1.protocolTypeCode=TCP&accessControlGroupRuleList.1.ipBlock=$IP/32&accessControlGroupRuleList.1.portRange=8888"
-
-	echo $IP
+	URI="/server/v2/$NCP_SERVER_API_PATH?serverInstanceNoList.1=$NGRINDER_AGENT&serverInstanceNoList.2=$NGRINDER_CONTROLLER"
 
 	SIG="$METHOD"' '"$URI"${nl}
 	SIG+="$TIMESTAMP"${nl}


### PR DESCRIPTION
## 개요
- 관련 Issue 번호 : #62 

## 작업사항
- nGrinder 서버는 필요할 때만 사용하기 때문세 서버 비용 절감을 위해 cron job으로 
   nCloud server API를 활용해 오후 1시 ~ 19시 까지만 운영되도록 했습니다. 